### PR TITLE
Fix references to old repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# xVimscript
+# Exercism Vim script Track
 
-![build status](https://travis-ci.org/exercism/xvimscript.svg?branch=master)
+![build status](https://travis-ci.org/exercism/vimscript.svg?branch=master)
 [![Join the chat at https://gitter.im/exercism/xvimscript](https://badges.gitter.im/exercism/xvimscript.svg)](https://gitter.im/exercism/xvimscript?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Exercism exercises in Vim script.
@@ -10,12 +10,12 @@ Exercism exercises in Vim script.
 We welcome any kind of contribution!
 
 If you have a suggestion or question, create a new
-[issue](https://github.com/exercism/xvimscript/issues).
+[issue](https://github.com/exercism/vimscript/issues).
 
 For code or fixing typos and similar things, open a
-[pull request](https://github.com/exercism/xvimscript/pulls).
+[pull request](https://github.com/exercism/vimscript/pulls).
 
-Look at recent [commits](https://github.com/exercism/xvimscript/commits/master)
+Look at recent [commits](https://github.com/exercism/vimscript/commits/master)
 to get a feeling on how to format your own ones.
 
 Even if there are any uncertainties, go for it nevertheless. We can straighten


### PR DESCRIPTION
This fixes the travis build status badge.

I didn't update the gitter chat room reference, as that will probably need a manual change in gitter.