### PR TITLE
Move conditions from code comment to the instructions

### DIFF
--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -6,6 +6,12 @@ Given `"listen"` and a list of candidates like `"enlists" "google"
 "inlets" "banana"` the program should return a list containing
 `"inlets"`.
 
+A few extra conditions:
+
+- Same words don't match.
+- Cases are treated insensitively.
+- The returned list is sorted.
+
 # How to run the tests
 
 If you don't know how to run Vader tests, see:

--- a/exercises/anagram/anagram.vim
+++ b/exercises/anagram/anagram.vim
@@ -1,12 +1,6 @@
 "
 " Given a word and a list of possible anagrams, select the correct sublist.
 "
-" Hints:
-"
-"   - Same words don't match.
-"   - Cases are treated insensitivley.
-"   - The returned list is sorted.
-"
 " Example:
 "
 "   :echo Anagram('foo', ['foo', 'bar', 'oof', 'Ofo'])


### PR DESCRIPTION
Instead of splitting the conditions between the instructions and the code, better to keep them both in the same place. I have a practical situation where a student hadn''t noticed the additional constraints and was wondering why their tests were failing. I think this would help.

I could also keep them in both, but I feel like a "Hints:" section in the comments would be redundant.