### PR TITLE
Improve argument name in "leap" exercise

### DIFF
--- a/exercises/leap/example.vim
+++ b/exercises/leap/example.vim
@@ -1,3 +1,3 @@
-function! LeapYear(num) abort
-  return a:num % 400 == 0 || a:num % 4 == 0 && a:num % 100 != 0
+function! LeapYear(year) abort
+  return a:year % 400 == 0 || a:year % 4 == 0 && a:year % 100 != 0
 endfunction

--- a/exercises/leap/leap.vim
+++ b/exercises/leap/leap.vim
@@ -2,7 +2,7 @@
 " This function takes a year and returns 1 if it's a leap year
 " and 0 otherwise.
 "
-function! LeapYear(number) abort
+function! LeapYear(year) abort
 
   " your implementation goes here
 


### PR DESCRIPTION
The argument name `year` is better than `number` or `num` here.