### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ request.
 
 ## Writing test files
 
-#### Generating test files
+### Generating test files
 
 Use the [generator](lib/generate.vim) to create Vader files from their canonical
 test data:

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 [Vim](http://www.vim.org) is a decades old text editor that is still wildly popular among programmers and people who like working in terminal emulators.
 
 In Vim, keys don't always do the same things. 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -7,7 +7,7 @@ You need [Vim](http://www.vim.org) to do the exercises:
 - [Windows](#windows)
 - [Source](#source)
 
-#### macOS
+## macOS
 
 The OS ships with Vim by default, but it's a hopelessly outdated version.
 
@@ -30,7 +30,7 @@ $ sudo port install vim +huge
 If you want a GUI, have a look at [MacVim](https://macvim-dev.github.io/macvim)
 instead.
 
-#### Ubuntu / Debian
+## Ubuntu / Debian
 
 Install a full-fledged Vim with GUI support (`gvim`):
 
@@ -39,7 +39,7 @@ $ sudo apt-get update
 $ sudo apt-get install vim-gtk
 ```
 
-#### Windows
+## Windows
 
 Using [Chocolatey](https://chocolatey.org):
 
@@ -49,7 +49,7 @@ C:\> choco install vim
 
 Or download and install directly from [here](http://www.vim.org/download.php#pc).
 
-#### Source
+## Source
 
 If you want to compile the latest Vim yourself, check out the [official
 repository on GitHub](https://github.com/vim/vim).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,4 +1,4 @@
-## Installation
+# Installation
 
 You need [Vim](http://www.vim.org) to do the exercises:
 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,4 +1,4 @@
-## LEARNING
+# LEARNING
 
 Vim comes with great documentation built in already. The interface to the
 documentation is the `:help` command.

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,4 +1,4 @@
-## RESOURCES
+# RESOURCES
 
 #### General resources
 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,24 +1,24 @@
 # RESOURCES
 
-#### General resources
+## General resources
 
 - [vim-galore](https://github.com/mhinz/vim-galore) is a huge guide about all
   things Vim.
 - [Why, oh WHY, do those #?@! nutheads use vi?](http://www.viemu.com/a-why-vi-vim.html) explains common misconceptions about vi and Vim.
 - [Your problem with Vim is that you don't grok vi](http://stackoverflow.com/a/1220118) is a pure gem. Read it every once in a while.
 
-#### Vim scripting
+## Vim scripting
 
 - [Learn Vimscript the Hard Way](http://learnvimscriptthehardway.stevelosh.com)
 - [IBM DeveloperWorks: Scripting the Vim
   editor](http://www.ibm.com/developerworks/views/linux/libraryview.jsp?sort_order=asc&sort_by=Title&search_by=scripting+the+vim+editor)
 
-#### Books
+## Books
 
 There is only one good book about Vim out there: [Practical
 Vim](https://pragprog.com/book/dnvim2/practical-vim-second-edition).
 
-#### Screencasts
+## Screencasts
 
 - [vimcasts.org](http://vimcasts.org/episodes/archive)
 - [wincent on YouTube](https://www.youtube.com/channel/UCXPHFM88IlFn68OmLwtPmZA)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,4 @@
-## SETUP
+# SETUP
 
 This track uses two tools to run the test suite and ensure best practices:
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -5,7 +5,7 @@ This track uses two tools to run the test suite and ensure best practices:
 1. [vader.vim](https://github.com/junegunn/vader.vim)
 2. [vint](https://github.com/Kuniwak/vint)
 
-#### Running tests
+## Running tests
 
 1. Install [vader.vim](https://github.com/junegunn/vader.vim/#installation).
 1. Open your solution:
@@ -55,7 +55,7 @@ autocmd BufRead *.{vader,vim}
 Afterwards open any `.vim` or `.vader` file from an exercise directory and run
 the `:Test` command.
 
-#### Linting Vim files
+## Linting Vim files
 
 1. Install [vint](https://github.com/Kuniwak/vint#quick-start).
 1. Recursively lint all Vim files:


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
