### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "5d4eed4f-0701-450a-a5c0-3ed858df5345",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Vim script locally",
+      "blurb": "Learn how to install Vim script locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "fcb0506d-fd9d-4670-9fd3-9d5087f9f91a",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Vim script",
+      "blurb": "An overview of how to get started from scratch with Vim script"
+    },
+    {
+      "uuid": "9e05374e-4176-4258-baa5-d105daae9af1",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Vim script track",
+      "blurb": "Learn how to test your Vim script exercises on Exercism"
+    },
+    {
+      "uuid": "0621eeb1-38df-455f-93f9-7b473ec66446",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Vim script resources",
+      "blurb": "A collection of useful resources to help you master Vim script"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
