### PR TITLE
Change anagram test case input

### DIFF
--- a/exercises/practice/anagram/anagram.vader
+++ b/exercises/practice/anagram/anagram.vader
@@ -57,7 +57,7 @@ Execute (detects anagrams using case-insensitive possible matches):
   AssertEqual expected, FindAnagrams(candidates, subject)
 
 Execute (does not detect a anagram if the original word is repeated):
-  let candidates = ['go Go GO']
+  let candidates = ['go', 'Go', 'GO']
   let subject = "go"
   let expected = []
   AssertEqual expected, FindAnagrams(candidates, subject)


### PR DESCRIPTION
The test case fails the way it is written now.  The input for this function is supposed to be a list containing single word strings, as in all other test cases.