### PR TITLE
Vimscript to Vim script in track blurb

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
     "representer": false,
     "analyzer": false
   },
-  "blurb": "Vimscript (or VimL) is the programming language used for scripting the Vim text editor.",
+  "blurb": "Vim script (or VimL) is the programming language used for scripting the Vim text editor.",
   "version": 3,
   "online_editor": {
     "indent_style": "space",


### PR DESCRIPTION
The repo README and track docs all use 'Vim script' not 'Vimscript' unless it's a link to an external resource like https://learnvimscriptthehardway.stevelosh.com/.