### PR TITLE
Sort practice exercises by difficulty and name

### DIFF
--- a/config.json
+++ b/config.json
@@ -36,6 +36,15 @@
     "concept": [],
     "practice": [
       {
+        "slug": "etl",
+        "name": "ETL",
+        "uuid": "d0f80889-5c4e-4de6-b3a4-08a71a2e9c75",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "topics": [ "dict", "loops", "transforming" ]
+      },
+      {
         "slug": "hello-world",
         "name": "Hello World",
         "uuid": "a0d099f9-eda7-42d4-a4f6-284ae3178df1",
@@ -44,7 +53,7 @@
         "difficulty": 1,
         "topics": [
           "strings"
-        ]
+      ]
       },
       {
         "slug": "leap",
@@ -61,19 +70,6 @@
         ]
       },
       {
-        "slug": "hamming",
-        "name": "Hamming",
-        "uuid": "9cda4dfe-bdce-4a0b-9be2-ebafabd57271",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "equality",
-          "loops",
-          "strings"
-        ]
-      },
-      {
         "slug": "raindrops",
         "name": "Raindrops",
         "uuid": "e75e2331-1494-4e70-9ad4-3396a6aeccc3",
@@ -83,82 +79,6 @@
         "topics": [
           "conditionals",
           "filtering",
-          "strings"
-        ]
-      },
-      {
-        "slug": "scrabble-score",
-        "name": "Scrabble Score",
-        "uuid": "55859980-03d6-4994-a8e2-120179a8f0e5",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "dict",
-          "loops",
-          "strings"
-        ]
-      },
-      {
-        "slug": "word-count",
-        "name": "Word Count",
-        "uuid": "d85603b2-f143-48bd-8184-67959b53b1d0",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "dict",
-          "loops"
-        ]
-      },
-      {
-        "slug": "bob",
-        "name": "Bob",
-        "uuid": "345a440a-f995-4ead-9890-f5075c7f962e",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "conditionals",
-          "strings"
-        ]
-      },
-      {
-        "slug": "etl",
-        "name": "ETL",
-        "uuid": "d0f80889-5c4e-4de6-b3a4-08a71a2e9c75",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "dict",
-          "loops",
-          "transforming"
-        ]
-      },
-      {
-        "slug": "beer-song",
-        "name": "Beer Song",
-        "uuid": "73babd80-2a68-490f-a451-120918e5311c",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "formatting",
-          "loops",
-          "strings"
-        ]
-      },
-      {
-        "slug": "nucleotide-count",
-        "name": "Nucleotide Count",
-        "uuid": "ff92dd32-fa39-4b09-81ed-ab4b2ba4096d",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 4,
-        "topics": [
-          "dict",
-          "parsing",
           "strings"
         ]
       },
@@ -178,6 +98,18 @@
         "prerequisites": [],
         "difficulty": 1,
         "topics": []
+      },
+      {
+        "slug": "bob",
+        "name": "Bob",
+        "uuid": "345a440a-f995-4ead-9890-f5075c7f962e",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "conditionals",
+          "strings"
+        ]
       },
       {
         "slug": "difference-of-squares",
@@ -216,6 +148,27 @@
         ]
       },
       {
+        "slug": "scrabble-score",
+        "name": "Scrabble Score",
+        "uuid": "55859980-03d6-4994-a8e2-120179a8f0e5",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "dict",
+          "loops",
+          "strings"
+        ]
+      },
+      {
+        "slug": "two-fer",
+        "name": "Two Fer",
+        "uuid": "4d19f94f-c319-4b1d-8145-51ce01ad448d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2
+      },
+      {
         "slug": "atbash-cipher",
         "name": "Atbash Cipher",
         "uuid": "2cd8b4dd-0c07-4e62-9d49-ec9697dc978b",
@@ -227,6 +180,19 @@
           "cryptography",
           "strings",
           "transforming"
+        ]
+      },
+      {
+        "slug": "beer-song",
+        "name": "Beer Song",
+        "uuid": "73babd80-2a68-490f-a451-120918e5311c",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3,
+        "topics": [
+          "formatting",
+          "loops",
+          "strings"
         ]
       },
       {
@@ -242,14 +208,6 @@
           "math",
           "sequences"
         ]
-      },
-      {
-	"slug": "two-fer",
-	"name": "Two Fer",
-	"uuid": "4d19f94f-c319-4b1d-8145-51ce01ad448d",
-	"practices": [],
-	"prerequisites": [],
-	"difficulty":2
       },
       {
         "slug": "phone-number",
@@ -285,6 +243,18 @@
           "booleans",
           "conditionals",
           "logic"
+          ]
+      },
+      {
+        "slug": "word-count",
+        "name": "Word Count",
+        "uuid": "d85603b2-f143-48bd-8184-67959b53b1d0",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3,
+        "topics": [
+          "dict",
+          "loops"
         ]
       },
       {
@@ -297,6 +267,32 @@
         "topics": [
           "bitwise",
           "sorting"
+        ]
+      },
+      {
+        "slug": "hamming",
+        "name": "Hamming",
+        "uuid": "9cda4dfe-bdce-4a0b-9be2-ebafabd57271",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": [
+          "equality",
+          "loops",
+          "strings"
+        ]
+      },
+      {
+        "slug": "nucleotide-count",
+        "name": "Nucleotide Count",
+        "uuid": "ff92dd32-fa39-4b09-81ed-ab4b2ba4096d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4,
+        "topics": [ 
+          "dict",
+          "parsing",
+          "strings"
         ]
       },
       {

--- a/config.json
+++ b/config.json
@@ -91,6 +91,14 @@
         "difficulty": 1
       },
       {
+        "slug": "resistor-color-duo",
+        "name": "Resistor Color Duo",
+        "uuid": "8f00c858-c288-4dad-a7a8-a6592ce3dd15",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
         "slug": "rna-transcription",
         "name": "RNA Transcription",
         "uuid": "b8bc605a-527d-48d3-9963-a8325be122c1",
@@ -223,14 +231,6 @@
           "strings",
           "transforming"
         ]
-      },
-      {
-        "slug": "resistor-color-duo",
-        "name": "Resistor Color Duo",
-        "uuid": "8f00c858-c288-4dad-a7a8-a6592ce3dd15",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3
       },
       {
         "slug": "triangle",

--- a/config.json
+++ b/config.json
@@ -42,7 +42,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [ "dict", "loops", "transforming" ]
+        "topics": [
+          "dict",
+          "loops",
+          "transforming"
+        ]
       },
       {
         "slug": "hello-world",
@@ -53,7 +57,7 @@
         "difficulty": 1,
         "topics": [
           "strings"
-      ]
+        ]
       },
       {
         "slug": "leap",


### PR DESCRIPTION
I sorted the exercises by the current difficulty and then name. I made an exemption for `resistor-color-duo` and placed it after `resistor-color` to suggest that `resistor-color` naturally leads into `resistor-color-duo`. I saw this discussed on another track, and I liked the approach.