### PR TITLE
Deprecate beer-song in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -59,7 +59,8 @@
           "formatting",
           "loops",
           "strings"
-        ]
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "bob",


### PR DESCRIPTION
https://github.com/exercism/problem-specifications/blob/main/exercises/beer-song/.deprecated notes this exercise is deprecated. `bottle-song` is the replacement