### PR TITLE
Add space-age

### DIFF
--- a/config.json
+++ b/config.json
@@ -243,6 +243,14 @@
         ]
       },
       {
+        "slug": "space-age",
+        "name": "Space Age",
+        "uuid": "b672d6aa-0b3c-4aa9-8959-dd6f65049508",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
         "slug": "triangle",
         "name": "Triangle",
         "uuid": "33796a20-8325-4068-bdbd-e91519144b24",

--- a/exercises/practice/space-age/.docs/instructions.md
+++ b/exercises/practice/space-age/.docs/instructions.md
@@ -1,0 +1,25 @@
+# Instructions
+
+Given an age in seconds, calculate how old someone would be on:
+
+- Mercury: orbital period 0.2408467 Earth years
+- Venus: orbital period 0.61519726 Earth years
+- Earth: orbital period 1.0 Earth years, 365.25 Earth days, or 31557600 seconds
+- Mars: orbital period 1.8808158 Earth years
+- Jupiter: orbital period 11.862615 Earth years
+- Saturn: orbital period 29.447498 Earth years
+- Uranus: orbital period 84.016846 Earth years
+- Neptune: orbital period 164.79132 Earth years
+
+So if you were told someone were 1,000,000,000 seconds old, you should
+be able to say that they're 31.69 Earth-years old.
+
+If you're wondering why Pluto didn't make the cut, go watch [this YouTube video][pluto-video].
+
+Note: The actual length of one complete orbit of the Earth around the sun is closer to 365.256 days (1 sidereal year).
+The Gregorian calendar has, on average, 365.2425 days.
+While not entirely accurate, 365.25 is the value used in this exercise.
+See [Year on Wikipedia][year] for more ways to measure a year.
+
+[pluto-video]: https://www.youtube.com/watch?v=Z_2gbGXzFbs
+[year]: https://en.wikipedia.org/wiki/Year#Summary

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "BNAndras"
+  ],
+  "files": {
+    "solution": [
+      "space_age.vim"
+    ],
+    "test": [
+      "space_age.vader"
+    ],
+    "example": [
+      ".meta/example.vim"
+    ]
+  },
+  "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
+  "source": "Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial.",
+  "source_url": "https://pine.fm/LearnToProgram/?Chapter=01"
+}

--- a/exercises/practice/space-age/.meta/example.vim
+++ b/exercises/practice/space-age/.meta/example.vim
@@ -1,0 +1,22 @@
+let s:SecondsInEarthYear = 31557600.0
+
+let s:OrbitalRatios = {
+    \ 'Mercury':    0.2408467,
+    \ 'Venus':      0.61519726,
+    \ 'Earth':      1,
+    \ 'Mars':       1.8808158,
+    \ 'Jupiter':    11.862615,
+    \ 'Saturn':     29.447498,
+    \ 'Uranus':     84.016846,
+    \ 'Neptune':    164.79132
+    \ }
+
+function! Age(planet, seconds) abort
+    if !has_key(s:OrbitalRatios, a:planet)
+        throw 'not a planet'
+    endif
+
+    let l:years = a:seconds / s:SecondsInEarthYear
+    let l:ratio = get(s:OrbitalRatios, a:planet)
+    return l:years / l:ratio
+endfunction

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[84f609af-5a91-4d68-90a3-9e32d8a5cd34]
+description = "age on Earth"
+
+[ca20c4e9-6054-458c-9312-79679ffab40b]
+description = "age on Mercury"
+
+[502c6529-fd1b-41d3-8fab-65e03082b024]
+description = "age on Venus"
+
+[9ceadf5e-a0d5-4388-9d40-2c459227ceb8]
+description = "age on Mars"
+
+[42927dc3-fe5e-4f76-a5b5-f737fc19bcde]
+description = "age on Jupiter"
+
+[8469b332-7837-4ada-b27c-00ee043ebcad]
+description = "age on Saturn"
+
+[999354c1-76f8-4bb5-a672-f317b6436743]
+description = "age on Uranus"
+
+[80096d30-a0d4-4449-903e-a381178355d8]
+description = "age on Neptune"
+
+[57b96e2a-1178-40b7-b34d-f3c9c34e4bf4]
+description = "invalid planet causes error"

--- a/exercises/practice/space-age/space_age.vader
+++ b/exercises/practice/space-age/space_age.vader
@@ -1,0 +1,59 @@
+Before (helper to compare floats):
+  function! ApproximatelyEqual(a, b) abort
+    return abs(a:a - a:b) <= 0.01
+  endfunction
+
+Execute (age on Earth):
+  let g:planet = "Earth"
+  let g:seconds = 1000000000
+  let g:expected = 31.69
+  Assert ApproximatelyEqual(g:expected, Age(g:planet, g:seconds))
+
+Execute (age on Mercury):
+  let g:planet = "Mercury"
+  let g:seconds = 2134835688
+  let g:expected = 280.88
+  Assert ApproximatelyEqual(g:expected, Age(g:planet, g:seconds))
+
+Execute (age on Venus):
+  let g:planet = "Venus"
+  let g:seconds = 189839836
+  let g:expected = 9.78
+  Assert ApproximatelyEqual(g:expected, Age(g:planet, g:seconds))
+
+Execute (age on Mars):
+  let g:planet = "Mars"
+  let g:seconds = 2129871239
+  let g:expected = 35.88
+  Assert ApproximatelyEqual(g:expected, Age(g:planet, g:seconds))
+
+Execute (age on Jupiter):
+  let g:planet = "Jupiter"
+  let g:seconds = 901876382
+  let g:expected = 2.41
+  Assert ApproximatelyEqual(g:expected, Age(g:planet, g:seconds))
+
+Execute (age on Saturn):
+  let g:planet = "Saturn"
+  let g:seconds = 2000000000
+  let g:expected = 2.15
+  Assert ApproximatelyEqual(g:expected, Age(g:planet, g:seconds))
+
+Execute (age on Uranus):
+  let g:planet = "Uranus"
+  let g:seconds = 1210123456
+  let g:expected = 0.46
+  Assert ApproximatelyEqual(g:expected, Age(g:planet, g:seconds))
+
+Execute (age on Neptune):
+  let g:planet = "Neptune"
+  let g:seconds = 1821023456
+  let g:expected = 0.35
+  Assert ApproximatelyEqual(g:expected, Age(g:planet, g:seconds))
+
+Execute (invalid planet causes error):
+  let g:planet = "Sun"
+  let g:seconds = 680804807
+  let g:expected = "not a planet"
+  AssertThrows call Age(g:planet, g:seconds)
+  AssertEqual g:expected, g:vader_exception

--- a/exercises/practice/space-age/space_age.vim
+++ b/exercises/practice/space-age/space_age.vim
@@ -1,0 +1,7 @@
+"
+" Returns an age in local years, given a planet name and number of seconds on Earth
+" Raises an exception if the name is not a valid planet in the solar system
+"
+function! Age(planet, seconds) abort
+  " your code goes here
+endfunction


### PR DESCRIPTION
Related to #172.

I removed the usual examples from the function documentation since I didn't want to bias a student towards rounding to two digits or not.

Also, the Before block is awkward, but I couldn't define the predicate outside of it. The other option I saw was an Execute block, but that'll make the definition be seen as another test that passes every time (no assert). That's not a great solution.