### PR TITLE
Fix incorrect codepoint boundaries in isogram example

### DIFF
--- a/exercises/practice/isogram/.meta/example.vim
+++ b/exercises/practice/isogram/.meta/example.vim
@@ -4,7 +4,7 @@ function! IsIsogram(phrase) abort
     
     for l:char in split(l:phrase, '\zs')
         let l:cp = char2nr(char)
-        if (l:cp < 61 || l:cp > 123)
+        if (l:cp < 97 || l:cp > 122)
             continue
         endif
 


### PR DESCRIPTION
Lowercase a is 97 and lowercase Z is 122 per https://en.wikipedia.org/wiki/List_of_Unicode_characters#Latin_script