### PR TITLE
Remove invalid quotes from tests.toml for armstrong-numbers

### DIFF
--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -38,8 +38,8 @@ description = "Seven-digit number that is not an Armstrong number"
 
 [5ee2fdf8-334e-4a46-bb8d-e5c19c02c148]
 description = "Armstrong number containing seven zeroes"
-include = "false"
+include = false
 
 [12ffbf10-307a-434e-b4ad-c925680e1dd4]
 description = "The largest and last Armstrong number"
-include = "false"
+include = false


### PR DESCRIPTION
`configlet` is warning that "false" needs to be false.