### PR TITLE
Update CI to Vim 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,11 @@ jobs:
       - name: Install project dependencies
         run: |
           sudo apt-get update -q
-          sudo apt-get install vim-gtk
+          sudo apt-get install libncurses5-dev libncursesw5-dev git make build-essential
+          git clone https://github.com/vim/vim.git
+          cd vim/src
+          sudo make
+          sudo make install
 
       - name: Run exercism/vimscript ci (runs tests) for all exercises
         run: bin/ci


### PR DESCRIPTION
Once exercism/vimscript-test-runner#28 is merged, we can update the CI to support Vim 9. I opted to build Vim from source rather than use a PPA. This can work until the Ubuntu runner has a more modern Vim package available. Another approach would be to use our test runner image to test each exercise in isolation, which will require a little more research.