### PR TITLE
Use double quotes so that newlines are handled properly.

### DIFF
--- a/exercises/practice/transpose/.meta/example.vim
+++ b/exercises/practice/transpose/.meta/example.vim
@@ -5,7 +5,7 @@ function! Transpose(lines) abort
 
   let l:substituted = []
   let l:max_row_length = 0
-  for l:row in split(a:lines, '\\n')
+  for l:row in split(a:lines, "\n")
     let l:row = substitute(l:row, ' ', '*', 'g')
     if len(l:row) > l:max_row_length
       let l:max_row_length = len(l:row)
@@ -37,5 +37,5 @@ function! Transpose(lines) abort
     call add(l:results, l:row)
   endfor
 
-  return join(l:results, '\n')
+  return join(l:results, "\n")
 endfunction

--- a/exercises/practice/transpose/.meta/example.vim
+++ b/exercises/practice/transpose/.meta/example.vim
@@ -5,20 +5,17 @@ function! Transpose(lines) abort
 
   let l:substituted = []
   let l:max_row_length = 0
-  for l:row in split(a:lines, "\n")
+  for l:row in reverse(split(a:lines, "\n"))
     let l:row = substitute(l:row, ' ', '*', 'g')
     if len(l:row) > l:max_row_length
       let l:max_row_length = len(l:row)
+    else
+      let l:row .= repeat(' ', l:max_row_length - len(l:row))
     endif
-
     call add(l:substituted, l:row)
   endfor
 
-  let l:padded = []
-  for l:row in l:substituted
-    let l:row .= repeat(' ', l:max_row_length - len(l:row))
-    call add(l:padded, l:row)
-  endfor
+  let l:padded = reverse(l:substituted)
 
   let l:zipped = []
   let l:count = len(l:padded[0])

--- a/exercises/practice/transpose/transpose.vader
+++ b/exercises/practice/transpose/transpose.vader
@@ -2,83 +2,83 @@
 Execute (empty string):
   let g:lines = []
   let g:expected = []
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)
 
 Execute (two characters in a row):
   let g:lines = ['A1']
   let g:expected = ['A', '1']
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)
 
 Execute (two characters in a column):
   let g:lines = ['A', '1']
   let g:expected = ['A1']
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)
 
 Execute (simple):
   let g:lines = ['ABC', '123']
   let g:expected = ['A1', 'B2', 'C3']
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)
 
 Execute (single line):
   let g:lines = ['Single line.']
   let g:expected = ['S', 'i', 'n', 'g', 'l', 'e', ' ', 'l', 'i', 'n', 'e', '.']
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)
 
 Execute (first line longer than second line):
   let g:lines = ['The fourth line.', 'The fifth line.']
   let g:expected = ['TT', 'hh', 'ee', '  ', 'ff', 'oi', 'uf', 'rt', 'th', 'h ', ' l', 'li', 'in', 'ne', 'e.', '.']
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)
 
 Execute (second line longer than first line):
   let g:lines = ['The first line.', 'The second line.']
   let g:expected = ['TT', 'hh', 'ee', '  ', 'fs', 'ie', 'rc', 'so', 'tn', ' d', 'l ', 'il', 'ni', 'en', '.e', ' .']
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)
 
 Execute (mixed line length):
   let g:lines = ['The longest line.', 'A long line.', 'A longer line.', 'A line.']
   let g:expected = ['TAAA', 'h   ', 'elll', ' ooi', 'lnnn', 'ogge', 'n e.', 'glr', 'ei ', 'snl', 'tei', ' .n', 'l e', 'i .', 'n', 'e', '.']
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)
 
 Execute (square):
   let g:lines = ['HEART', 'EMBER', 'ABUSE', 'RESIN', 'TREND']
   let g:expected = ['HEART', 'EMBER', 'ABUSE', 'RESIN', 'TREND']
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)
 
 Execute (rectangle):
   let g:lines = ['FRACTURE', 'OUTLINED', 'BLOOMING', 'SEPTETTE']
   let g:expected = ['FOBS', 'RULE', 'ATOP', 'CLOT', 'TIME', 'UNIT', 'RENT', 'EDGE']
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)
 
 Execute (triangle):
   let g:lines = ['T', 'EE', 'AAA', 'SSSS', 'EEEEE', 'RRRRRR']
   let g:expected = ['TEASER', ' EASER', '  ASER', '   SER', '    ER', '     R']
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)
 
 Execute (jagged triangle):
   let g:lines = ['11', '2', '3333', '444', '555555', '66666']
   let g:expected = ['123456', '1 3456', '  3456', '  3 56', '    56', '    5']
-  let g:lines = join(g:lines, '\n')
-  let g:expected = join(g:expected, '\n')
+  let g:lines = join(g:lines, "\n")
+  let g:expected = join(g:expected, "\n")
   AssertEqual g:expected, Transpose(g:lines)

--- a/exercises/practice/transpose/transpose.vim
+++ b/exercises/practice/transpose/transpose.vim
@@ -4,13 +4,10 @@
 "
 " Example:
 "
-"   :echo Transpose('ABC\nDEF')
-"   " ABC
-"   " DEF
-"   ADn\BE\nCF
-"   " AD
-"   " BE
-"   " CF
+"   :echo Transpose("ABC\nDEF")
+"   AD
+"   BE
+"   CF
 "
 function! Transpose(lines) abort
   " your code goes here


### PR DESCRIPTION
The tests for transpose were using single quotes around \n, with the result that the two-character sequence backslash+n was being used instead of newlines to join lines together.  Solutions had to accept input in this unusual format and return the result in the same style.  This change switches to double quotes, so that newlines are used as expected.  Also clean up a garbled comment in the stub code.

This was discussed in the forum: https://forum.exercism.org/t/wrong-line-joins-in-transpose/9005