### PR TITLE
Set grains to WIP

### DIFF
--- a/config.json
+++ b/config.json
@@ -185,7 +185,8 @@
         "uuid": "99408193-d0ce-4c68-8cab-e680f3ed56a4",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 2
+        "difficulty": 2,
+        "status": "wip"
       },
       {
         "slug": "hello-world",


### PR DESCRIPTION
Until #256 is resolved, I'd propose we not show grains on the track. `status: "wip"` will set it so only maintainers can see the exercise on the Exercism website. When grains is fixed, we can remove that added line and the exercise will go back to active status by default.