### PR TITLE
Forego parallel-letter-frequency

### DIFF
--- a/config.json
+++ b/config.json
@@ -611,6 +611,7 @@
       }
     ],
     "foregone": [
+      "parallel-letter-frequency",
       "lens-person"
     ]
   },


### PR DESCRIPTION
Vim script doesn't seem to natively support parallel code execution unless I'm missing something obvious.