### PR TITLE
Sync docs and metadata

### DIFF
--- a/exercises/practice/darts/.docs/instructions.md
+++ b/exercises/practice/darts/.docs/instructions.md
@@ -1,6 +1,6 @@
 # Instructions
 
-Write a function that returns the earned points in a single toss of a Darts game.
+Calculate the points scored in a single toss of a Darts game.
 
 [Darts][darts] is a game where players throw darts at a [target][darts-target].
 
@@ -16,7 +16,7 @@ In our particular instance of the game, the target rewards 4 different amounts o
 The outer circle has a radius of 10 units (this is equivalent to the total radius for the entire target), the middle circle a radius of 5 units, and the inner circle a radius of 1.
 Of course, they are all centered at the same point — that is, the circles are [concentric][] defined by the coordinates (0, 0).
 
-Write a function that given a point in the target (defined by its [Cartesian coordinates][cartesian-coordinates] `x` and `y`, where `x` and `y` are [real][real-numbers]), returns the correct amount earned by a dart landing at that point.
+Given a point in the target (defined by its [Cartesian coordinates][cartesian-coordinates] `x` and `y`, where `x` and `y` are [real][real-numbers]), calculate the correct score earned by a dart landing at that point.
 
 ## Credit
 

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -13,6 +13,6 @@
       ".meta/example.vim"
     ]
   },
-  "blurb": "Write a function that returns the earned points in a single toss of a Darts game.",
+  "blurb": "Calculate the points scored in a single toss of a Darts game.",
   "source": "Inspired by an exercise created by a professor Della Paolera in Argentina"
 }

--- a/exercises/practice/flatten-array/.docs/instructions.md
+++ b/exercises/practice/flatten-array/.docs/instructions.md
@@ -2,7 +2,7 @@
 
 Take a nested list and return a single flattened list with all values except nil/null.
 
-The challenge is to write a function that accepts an arbitrarily-deep nested list-like structure and returns a flattened structure without any nil/null values.
+The challenge is to take an arbitrarily-deep nested list-like structure and produce a flattened structure without any nil/null values.
 
 For example:
 

--- a/exercises/practice/leap/.approaches/config.json
+++ b/exercises/practice/leap/.approaches/config.json
@@ -1,27 +1,27 @@
 {
-    "introduction": {
+  "introduction": {
+    "authors": [
+      "BNAndras"
+    ]
+  },
+  "approaches": [
+    {
+      "uuid": "2e660e58-f799-4396-b07d-d0f067efbef3",
+      "slug": "boolean-chain",
+      "title": "Boolean Chaining",
+      "blurb": "Use operators to check boolean values in a chain",
       "authors": [
         "BNAndras"
       ]
     },
-    "approaches": [
-      {
-        "uuid": "2e660e58-f799-4396-b07d-d0f067efbef3",
-        "slug": "boolean-chain",
-        "title": "Boolean Chaining",
-        "blurb": "Use operators to check boolean values in a chain",
-        "authors": [
-          "BNAndras"
-        ]
-      },
-      {
-        "uuid": "669b6557-0bf4-43fd-a500-f88eed0a151c",
-        "slug": "if-else-statements",
-        "title": "If Else Statements",
-        "blurb": "Use if else statements to check boolean values sequentially.",
-        "authors": [
-          "BNAndras"
-        ]
-      }
-    ]
+    {
+      "uuid": "669b6557-0bf4-43fd-a500-f88eed0a151c",
+      "slug": "if-else-statements",
+      "title": "If Else Statements",
+      "blurb": "Use if else statements to check boolean values sequentially.",
+      "authors": [
+        "BNAndras"
+      ]
+    }
+  ]
 }

--- a/exercises/practice/two-bucket/.docs/instructions.md
+++ b/exercises/practice/two-bucket/.docs/instructions.md
@@ -11,7 +11,7 @@ There are some rules that your solution must follow:
      b) the second bucket is full
   2. Emptying a bucket and doing nothing to the other.
   3. Filling a bucket and doing nothing to the other.
-- After an action, you may not arrive at a state where the starting bucket is empty and the other bucket is full.
+- After an action, you may not arrive at a state where the initial starting bucket is empty and the other bucket is full.
 
 Your program will take as input:
 


### PR DESCRIPTION
Just a `configlet sync` and `configlet fmt`.

As a heads-up, I noticed the Emacs Lisp track had a few exercises that had unimplemented tests that had been marked as present in the tests.toml files. That happened because the toml files were auto-generated three years ago, but the exercise test suites were much older. So I'm planning on iterating through the Emacs Lisp, Racket, and Vim script tracks over the next few weeks to find and update tests as needed.