### PR TITLE
Sync phone number tests

### DIFF
--- a/exercises/practice/phone-number/phone_number.vader
+++ b/exercises/practice/phone-number/phone_number.vader
@@ -1,32 +1,90 @@
-Execute (cleans the number):
-  AssertEqual '2234567890', ToNANP('(223) 456-7890')
 
-Execute (cleans numbers with dots):
-  AssertEqual '2234567890', ToNANP('223.456.7890')
+Execute (ToNANPs the number):
+  let g:phrase = "(223) 456-7890"
+  let g:expected = "2234567890"
+  AssertEqual g:expected, ToNANP(g:phrase)
 
-Execute (cleans numbers with multiple spaces):
-  AssertEqual '2234567890', ToNANP('223 456    7890')
+Execute (ToNANPs numbers with dots):
+  let g:phrase = "223.456.7890"
+  let g:expected = "2234567890"
+  AssertEqual g:expected, ToNANP(g:phrase)
+
+Execute (ToNANPs numbers with multiple spaces):
+  let g:phrase = "223 456   7890   "
+  let g:expected = "2234567890"
+  AssertEqual g:expected, ToNANP(g:phrase)
 
 Execute (invalid when 9 digits):
-  AssertEqual '', ToNANP('123456789')
+  let g:phrase = "123456789"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
 
-Execute (invalid when 11 digits and does not start with 1):
-  AssertEqual '', ToNANP('22234567890')
+Execute (invalid when 11 digits does not start with a 1):
+  let g:phrase = "22234567890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
 
-Execute (valid when 11 digits and does start with 1):
-  AssertEqual '2234567890', ToNANP('12234567890')
+Execute (valid when 11 digits and starting with 1):
+  let g:phrase = "12234567890"
+  let g:expected = "2234567890"
+  AssertEqual g:expected, ToNANP(g:phrase)
 
 Execute (valid when 11 digits and starting with 1 even with punctuation):
-  AssertEqual '2234567890', ToNANP('+1 (223) 456-7890')
+  let g:phrase = "+1 (223) 456-7890"
+  let g:expected = "2234567890"
+  AssertEqual g:expected, ToNANP(g:phrase)
+
+Execute (invalid when more than 11 digits):
+  let g:phrase = "321234567890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
 
 Execute (invalid with letters):
-  AssertEqual '', ToNANP('123-abc-7890')
+  let g:phrase = "523-abc-7890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
 
 Execute (invalid with punctuations):
-  AssertEqual '', ToNANP('123-@:!-7890')
+  let g:phrase = "523-@:!-7890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
 
-Execute (invalid if area code does not start with 2-9):
-  AssertEqual '', ToNANP('(123) 456-7890')
+Execute (invalid if area code starts with 0):
+  let g:phrase = "(023) 456-7890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
 
-Execute (invalid if exchange code does not start with 2-9):
-  AssertEqual '', ToNANP('(223) 056-7890')
+Execute (invalid if area code starts with 1):
+  let g:phrase = "(123) 456-7890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
+
+Execute (invalid if exchange code starts with 0):
+  let g:phrase = "(223) 056-7890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
+
+Execute (invalid if exchange code starts with 1):
+  let g:phrase = "(223) 156-7890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
+
+Execute (invalid if area code starts with 0 on valid 11-digit number):
+  let g:phrase = "1 (023) 456-7890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
+
+Execute (invalid if area code starts with 1 on valid 11-digit number):
+  let g:phrase = "1 (123) 456-7890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
+
+Execute (invalid if exchange code starts with 0 on valid 11-digit number):
+  let g:phrase = "1 (223) 056-7890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)
+
+Execute (invalid if exchange code starts with 1 on valid 11-digit number):
+  let g:phrase = "1 (223) 156-7890"
+  let g:expected = ""
+  AssertEqual g:expected, ToNANP(g:phrase)


### PR DESCRIPTION
The missing tests here seem to be input validation ones. The implementation expects an empty string to be returned instead of an error thrown so nothing significant changed here I believe.