### PR TITLE
Bump CI to Ubuntu 24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
       image: exercism/vimscript-test-runner
 


### PR DESCRIPTION
I'm bumping the CI to Ubuntu 24.04, but we're using the test runner image to do the actual exercise testing so this shouldn't be a major deal.