### PR TITLE
Rename two exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -356,7 +356,7 @@
       },
       {
         "slug": "protein-translation",
-        "name": "Protein Translaton",
+        "name": "Protein Translation",
         "uuid": "4d510ad3-4d37-491a-99c6-892fbe5bd095",
         "practices": [],
         "prerequisites": [],
@@ -543,7 +543,7 @@
       },
       {
         "slug": "two-fer",
-        "name": "Two Fer",
+        "name": "Two-Fer",
         "uuid": "4d19f94f-c319-4b1d-8145-51ce01ad448d",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
Now all practice exercises have names consistent with problem-specifications metadata

https://github.com/exercism/problem-specifications/blob/main/exercises/protein-translation/metadata.toml

https://github.com/exercism/problem-specifications/blob/main/exercises/two-fer/metadata.toml

[no important files changed]