### PR TITLE
Reformat expected lines in `food-chain`

### DIFF
--- a/exercises/practice/food-chain/food_chain.vader
+++ b/exercises/practice/food-chain/food_chain.vader
@@ -1,60 +1,165 @@
-
 Execute (fly):
   let g:endVerse = 1
   let g:startVerse = 1
-  let g:expected = ['I know an old lady who swallowed a fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.']
+  let g:expected = [
+  \ "I know an old lady who swallowed a fly.",
+  \ "I don't know why she swallowed the fly. Perhaps she'll die."]
   AssertEqual g:expected, Recite(g:endVerse, g:startVerse)
 
 Execute (spider):
   let g:endVerse = 2
   let g:startVerse = 2
-  let g:expected = ['I know an old lady who swallowed a spider.', 'It wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.']
+  let g:expected = [
+  \ "I know an old lady who swallowed a spider.",
+  \ "It wriggled and jiggled and tickled inside her.",
+  \ "She swallowed the spider to catch the fly.", 
+  \ "I don't know why she swallowed the fly. Perhaps she'll die."]
   AssertEqual g:expected, Recite(g:endVerse, g:startVerse)
 
 Execute (bird):
   let g:endVerse = 3
   let g:startVerse = 3
-  let g:expected = ['I know an old lady who swallowed a bird.', 'How absurd to swallow a bird!', 'She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.']
+  let g:expected = [
+  \ "I know an old lady who swallowed a bird.", 
+  \ "How absurd to swallow a bird!", 
+  \ "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.", 
+  \ "She swallowed the spider to catch the fly.", 
+  \ "I don't know why she swallowed the fly. Perhaps she'll die."]
   AssertEqual g:expected, Recite(g:endVerse, g:startVerse)
 
 Execute (cat):
   let g:endVerse = 4
   let g:startVerse = 4
-  let g:expected = ['I know an old lady who swallowed a cat.', 'Imagine that, to swallow a cat!', 'She swallowed the cat to catch the bird.', 'She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.']
+  let g:expected = [
+  \ "I know an old lady who swallowed a cat.", 
+  \ "Imagine that, to swallow a cat!", 
+  \ "She swallowed the cat to catch the bird.", 
+  \ "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.", 
+  \ "She swallowed the spider to catch the fly.", 
+  \ "I don't know why she swallowed the fly. Perhaps she'll die."]
   AssertEqual g:expected, Recite(g:endVerse, g:startVerse)
 
 Execute (dog):
   let g:endVerse = 5
   let g:startVerse = 5
-  let g:expected = ['I know an old lady who swallowed a dog.', 'What a hog, to swallow a dog!', 'She swallowed the dog to catch the cat.', 'She swallowed the cat to catch the bird.', 'She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.']
+  let g:expected = [
+  \ "I know an old lady who swallowed a dog.",
+  \ "What a hog, to swallow a dog!", 
+  \ "She swallowed the dog to catch the cat.", 
+  \ "She swallowed the cat to catch the bird.",
+  \ "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+  \ "She swallowed the spider to catch the fly.", 
+  \ "I don't know why she swallowed the fly. Perhaps she'll die."]
   AssertEqual g:expected, Recite(g:endVerse, g:startVerse)
 
 Execute (goat):
   let g:endVerse = 6
   let g:startVerse = 6
-  let g:expected = ['I know an old lady who swallowed a goat.', 'Just opened her throat and swallowed a goat!', 'She swallowed the goat to catch the dog.', 'She swallowed the dog to catch the cat.', 'She swallowed the cat to catch the bird.', 'She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.']
+  let g:expected = [
+  \ "I know an old lady who swallowed a goat.", 
+  \ "Just opened her throat and swallowed a goat!",
+  \ "She swallowed the goat to catch the dog.", 
+  \ "She swallowed the dog to catch the cat.", 
+  \ "She swallowed the cat to catch the bird.",
+  \ "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+  \ "She swallowed the spider to catch the fly.",
+  \ "I don't know why she swallowed the fly. Perhaps she'll die."]
   AssertEqual g:expected, Recite(g:endVerse, g:startVerse)
 
 Execute (cow):
   let g:endVerse = 7
   let g:startVerse = 7
-  let g:expected = ['I know an old lady who swallowed a cow.', 'I don''t know how she swallowed a cow!', 'She swallowed the cow to catch the goat.', 'She swallowed the goat to catch the dog.', 'She swallowed the dog to catch the cat.', 'She swallowed the cat to catch the bird.', 'She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.']
+  let g:expected = [
+  \ "I know an old lady who swallowed a cow.",
+  \ "I don't know how she swallowed a cow!", 
+  \ "She swallowed the cow to catch the goat.", 
+  \ "She swallowed the goat to catch the dog.",
+  \ "She swallowed the dog to catch the cat.", 
+  \ "She swallowed the cat to catch the bird.", 
+  \ "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.", 
+  \ "She swallowed the spider to catch the fly.", 
+  \ "I don't know why she swallowed the fly. Perhaps she'll die."]
   AssertEqual g:expected, Recite(g:endVerse, g:startVerse)
 
 Execute (horse):
   let g:endVerse = 8
   let g:startVerse = 8
-  let g:expected = ['I know an old lady who swallowed a horse.', 'She''s dead, of course!']
+  let g:expected = [
+  \ "I know an old lady who swallowed a horse.",
+  \ "She's dead, of course!"]
   AssertEqual g:expected, Recite(g:endVerse, g:startVerse)
 
 Execute (multiple verses):
   let g:endVerse = 3
   let g:startVerse = 1
-  let g:expected = ['I know an old lady who swallowed a fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.', '', 'I know an old lady who swallowed a spider.', 'It wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.', '', 'I know an old lady who swallowed a bird.', 'How absurd to swallow a bird!', 'She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.']
+  let g:expected = [
+  \ "I know an old lady who swallowed a fly.",
+  \ "I don't know why she swallowed the fly. Perhaps she'll die.",
+  \ "",
+  \ "I know an old lady who swallowed a spider.",
+  \ "It wriggled and jiggled and tickled inside her.",
+  \ "She swallowed the spider to catch the fly.",
+  \ "I don't know why she swallowed the fly. Perhaps she'll die.",
+  \ "", 
+  \ "I know an old lady who swallowed a bird.",
+  \ "How absurd to swallow a bird!",
+  \ "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+  \ "She swallowed the spider to catch the fly.", 
+  \ "I don't know why she swallowed the fly. Perhaps she'll die."]
   AssertEqual g:expected, Recite(g:endVerse, g:startVerse)
 
 Execute (full song):
   let g:endVerse = 8
   let g:startVerse = 1
-  let g:expected = ['I know an old lady who swallowed a fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.', '', 'I know an old lady who swallowed a spider.', 'It wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.', '', 'I know an old lady who swallowed a bird.', 'How absurd to swallow a bird!', 'She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.', '', 'I know an old lady who swallowed a cat.', 'Imagine that, to swallow a cat!', 'She swallowed the cat to catch the bird.', 'She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.', '', 'I know an old lady who swallowed a dog.', 'What a hog, to swallow a dog!', 'She swallowed the dog to catch the cat.', 'She swallowed the cat to catch the bird.', 'She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.', '', 'I know an old lady who swallowed a goat.', 'Just opened her throat and swallowed a goat!', 'She swallowed the goat to catch the dog.', 'She swallowed the dog to catch the cat.', 'She swallowed the cat to catch the bird.', 'She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.', '', 'I know an old lady who swallowed a cow.', 'I don''t know how she swallowed a cow!', 'She swallowed the cow to catch the goat.', 'She swallowed the goat to catch the dog.', 'She swallowed the dog to catch the cat.', 'She swallowed the cat to catch the bird.', 'She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.', 'She swallowed the spider to catch the fly.', 'I don''t know why she swallowed the fly. Perhaps she''ll die.', '', 'I know an old lady who swallowed a horse.', 'She''s dead, of course!']
+  let g:expected = [
+  \ "I know an old lady who swallowed a fly.",
+  \ "I don't know why she swallowed the fly. Perhaps she'll die.",
+  \ "",
+  \ "I know an old lady who swallowed a spider.",
+  \ "It wriggled and jiggled and tickled inside her.",
+  \ "She swallowed the spider to catch the fly.",
+  \ "I don't know why she swallowed the fly. Perhaps she'll die.",
+  \ "",
+  \ "I know an old lady who swallowed a bird.",
+  \ "How absurd to swallow a bird!",
+  \ "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+  \ "She swallowed the spider to catch the fly.",
+  \ "I don't know why she swallowed the fly. Perhaps she'll die.",
+  \ "",
+  \ "I know an old lady who swallowed a cat.",
+  \ "Imagine that, to swallow a cat!",
+  \ "She swallowed the cat to catch the bird.",
+  \ "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+  \ "She swallowed the spider to catch the fly.",
+  \ "I don't know why she swallowed the fly. Perhaps she'll die.",
+  \ "",
+  \ "I know an old lady who swallowed a dog.",
+  \ "What a hog, to swallow a dog!",
+  \ "She swallowed the dog to catch the cat.",
+  \ "She swallowed the cat to catch the bird.",
+  \ "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+  \ "She swallowed the spider to catch the fly.",
+  \ "I don't know why she swallowed the fly. Perhaps she'll die.",
+  \ "",
+  \ "I know an old lady who swallowed a goat.",
+  \ "Just opened her throat and swallowed a goat!",
+  \ "She swallowed the goat to catch the dog.",
+  \ "She swallowed the dog to catch the cat.",
+  \ "She swallowed the cat to catch the bird.",
+  \ "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+  \ "She swallowed the spider to catch the fly.",
+  \ "I don't know why she swallowed the fly. Perhaps she'll die.",
+  \ "",
+  \ "I know an old lady who swallowed a cow.",
+  \ "I don't know how she swallowed a cow!",
+  \ "She swallowed the cow to catch the goat.",
+  \ "She swallowed the goat to catch the dog.",
+  \ "She swallowed the dog to catch the cat.",
+  \ "She swallowed the cat to catch the bird.",
+  \ "She swallowed the bird to catch the spider that wriggled and jiggled and tickled inside her.",
+  \ "She swallowed the spider to catch the fly.",
+  \ "I don't know why she swallowed the fly. Perhaps she'll die.",
+  \ "",
+  \ "I know an old lady who swallowed a horse.",
+  \ "She's dead, of course!"]
   AssertEqual g:expected, Recite(g:endVerse, g:startVerse)


### PR DESCRIPTION
The tests pane on the website wraps the expected list but reading it can be a bit difficult.
<img width="711" height="435" alt="image" src="https://github.com/user-attachments/assets/08822fe9-6875-4836-ad52-1b71d4b1b63a" />

Here's an example from Arturo where each expected line starts at the same indent level as the others so it'd be easier to read.
<img width="711" height="435" alt="image" src="https://github.com/user-attachments/assets/eb89b7b5-306f-4935-b72c-15fec7a2185f" />

