### PR TITLE
Flip order of `atbash-cipher` functions

### DIFF
--- a/exercises/practice/atbash-cipher/atbash_cipher.vim
+++ b/exercises/practice/atbash-cipher/atbash_cipher.vim
@@ -14,10 +14,10 @@
 "   thequickbrownfoxjumpsoverthelazydog
 "
 
-function! AtbashDecode(cipher) abort
+function! AtbashEncode(plaintext) abort
   " your code goes here
 endfunction
 
-function! AtbashEncode(plaintext) abort
+function! AtbashDecode(cipher) abort
   " your code goes here
 endfunction


### PR DESCRIPTION
AtbashEncode appears first in the test suite so it should appear first in the stub. I wasn't paying attention when solving this exercise and did the encoding logic inside AtbashDecode by accident.